### PR TITLE
Fix the game crashing when bumping into a wall with the knight transformation

### DIFF
--- a/scripts/scr_player_knightpepslopes/scr_player_knightpepslopes.gml
+++ b/scripts/scr_player_knightpepslopes/scr_player_knightpepslopes.gml
@@ -74,7 +74,7 @@ function scr_player_knightpepslopes()
 			movespeed = 0;
 			vsp = -6;
 			sprite_index = spr_knightpepbump;
-			image_index = floorimage_number - 1;
+			image_index = floor(image_number - 1);
 			state = states.knightpepbump;
 			fmod_event_one_shot_3d("event:/sfx/pep/groundpound", x, y);
 		}


### PR DESCRIPTION
Simple fix. This seems to be an OpenTower bug.
Can't test because I don't have the latest version of GMLive (and IDK if the 2.3.7 one I have would work), but it should work.
(i was gonna do this on a separate branch on my fork but i forgot to switch so i accidentally commited on master)